### PR TITLE
Empty style data on destroy produced an error

### DIFF
--- a/jquery.dotdotdot.js
+++ b/jquery.dotdotdot.js
@@ -164,7 +164,7 @@
 						.unbind_events()
 						.empty()
 						.append( orgContent )
-						.attr( 'style', $dot.data( 'dotdotdot-style' ) )
+						.attr( 'style', $dot.data( 'dotdotdot-style' ) || '' )
 						.data( 'dotdotdot', false );
 				}
 			);


### PR DESCRIPTION
If `$dot.data( 'dotdotdot-style' )` is empty, `attr` returns the current style because the second parameter is undefined and the last line fails.
