### PR TITLE
Add in some lovely ignores

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -15,6 +15,12 @@
     "overflow",
     "dots"
   ],
+  "ignore": [
+    ".jshintrc",
+    "index.html",
+    "*.json",
+    "README.md"
+  ],
   "dependencies": {
     "jquery": ">= 1.4.3"
   }


### PR DESCRIPTION
Added some ignores to your bower.json file.

Why?
- .jshintrc: in case you want to do some linting in the future
- index.html: This can be a security concern for some sites (like the one I am making now) 
- *.json, so I dont get the bower.json information on a live site
- README.md, again, I dont need this in my app. 

Thanks! 
