### PR TITLE
Fixes the bug when only first child is shown

### DIFF
--- a/src/js/jquery.dotdotdot.js
+++ b/src/js/jquery.dotdotdot.js
@@ -382,12 +382,7 @@
 					}
 
 					$e.detach();
-
-					if ( after )
-					{
-						after.detach();
-					}
-
+					
 					return false;
 				}
 			);


### PR DESCRIPTION
I've rewritten ellipsis function because I wasn't able
to work with the old implementation. The new one works
ok for all my examples + the buggy one when more than
one child needs to be shown but it's only the first one
that is shown.
