### PR TITLE
Use literal … instead of three dots (... vs …)

### DIFF
--- a/src/js/jquery.dotdotdot.js
+++ b/src/js/jquery.dotdotdot.js
@@ -280,7 +280,7 @@
 
 	//	public
 	$.fn.dotdotdot.defaults = {
-		'ellipsis'			: '... ',
+		'ellipsis'			: '\u2026 ',
 		'wrap'				: 'word',
 		'fallbackToLetter'	: true,
 		'lastCharacter'		: {},


### PR DESCRIPTION
This could possibly be inlined but the entity code approach could avoid some character encoding issues where people aren’t using utf-8?
