### PR TITLE
Put the destroy after the assignation of own style

### DIFF
--- a/src/js/jquery.dotdotdot.js
+++ b/src/js/jquery.dotdotdot.js
@@ -39,16 +39,16 @@
 
 		var $dot = this;
 
-		if ( $dot.data( 'dotdotdot' ) )
-		{
-			$dot.trigger( 'destroy.dot' );
-		}
-
 		$dot.data( 'dotdotdot-style', $dot.attr( 'style' ) || '' );
 		$dot.css( 'word-wrap', 'break-word' );
 		if ($dot.css( 'white-space' ) === 'nowrap')
 		{
 			$dot.css( 'white-space', 'normal' );
+		}
+		
+		if ( $dot.data( 'dotdotdot' ) )
+		{
+			$dot.trigger( 'destroy.dot' );
 		}
 
 		$dot.bind_events = function()


### PR DESCRIPTION
This is to keep the style attribute as they was before the call of dotdotdot() function.

If you don't do this way, at the line 169, the "$dot.data( 'dotdotdot-style' )" will always be empty...