### PR TITLE
Remove bower version from JSON file

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,6 @@
 {
   "name": "jQuery.dotdotdot",
   "main": "src/js/jquery.dotdotdot.js",
-  "version": "1.6.14",
   "homepage": "http://dotdotdot.frebsite.nl/",
   "authors": [
     "Fred Heusschen <info@frebsite.nl>"


### PR DESCRIPTION
I suggest removing the version from bower.json, it is optional per the specs,  and during the release of 1.6.15 the version was not bumped, producing this error when installing:

```
bower extract       jQuery.dotdotdot#* archive.tar.gz
bower mismatch      Version declared in the json (1.6.14) is different than the resolved one (1.6.15)
bower resolved      git://github.com/BeSite/jQuery.dotdotdot.git#1.6.15
```
