### PR TITLE
add class "is-truncated" to element when trancation is done

### DIFF
--- a/src/js/jquery.dotdotdot.js
+++ b/src/js/jquery.dotdotdot.js
@@ -57,6 +57,7 @@
 				'update.dot',
 				function( e, c )
 				{
+					$dot.removeClass("is-truncated");
 					e.preventDefault();
 					e.stopPropagation();
 

--- a/src/js/jquery.dotdotdot.js
+++ b/src/js/jquery.dotdotdot.js
@@ -403,7 +403,7 @@
 					}
 				}
 			);
-
+		$d.addClass("is-truncated");
 		return isTruncated;
 	}
 	function ellipsisElement( $e, $d, $i, o, after )


### PR DESCRIPTION
When using `jQuery.dotdotdot`, it's disturbing to see the text in its full length before it's truncated. 
By adding the class `is-truncated` to the element, when the trancation is done, this can be prevented.