### PR TITLE
publish to npm

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 # Ignore Mac system files.
 ._*
+.idea

--- a/package.json
+++ b/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "jQuery.dotdotdot",
+  "version": "1.6.16",
+  "description": "A jQuery plugin for advanced cross-browser ellipsis on multiple line content.",
+  "main": " ",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/BeSite/jQuery.dotdotdot.git"
+  },
+  "keywords": [
+    "jquery"
+  ],
+  "author": "Fred Heusschen <info@frebsite.nl>",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/BeSite/jQuery.dotdotdot/issues"
+  },
+  "homepage": "https://github.com/BeSite/jQuery.dotdotdot"
+}


### PR DESCRIPTION
NPM is becoming the standard way to distribute JavaScript-based code libraries, both browser-based and server-based. It would be great if jQuery.dotdotdot was available on npm as well. And it's pretty simple to do this. 

I already created a package.json for you in this pull request.  Simply create an npm account, log into your account locally (`npm login`) and then publish this to npm via `npm publish`.

I noticed you are currently publishing to bower and the jQuery plug-in registry.  NPM seems to be where all JavaScript dependencies (server and browser-based) are moving to.  Also, the jQuery plug-in registry is no longer being maintained by the jQuery team, and no updates to libraries are being accepted.  Most likely, bower will be completely replaced by npm in the near future as well.