### PR TITLE
make sure not to add "after" twice

### DIFF
--- a/src/js/jquery.dotdotdot.js
+++ b/src/js/jquery.dotdotdot.js
@@ -370,7 +370,7 @@
 					else
 					{
 						$elem.append( $e );
-						if ( after )
+						if ( after && !$e.is( o.after ) && !$e.find( o.after ).length  )
 						{
 							$elem[ $elem.is( notx ) ? 'after' : 'append' ]( after );
 						}


### PR DESCRIPTION
It is possible to add the after element(s) twice.  

For example say you have the simple case of two spans:  
````
<span>long_file_name_for_example</span><span class="file-type">.jpg</span>
````
if file-type is the after class, then the algorithm will fit the first span with the "after" span added, then it will attempt to add the "after" span as a second element, but will add the "after" span again because its supposed to be after.  Huh!

The commit just checks to make sure that the element just added is not the after element, or does not contain the after element. 