### PR TITLE
Add repository field to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,10 @@
   "main": "src/js/jquery.dotdotdot.js",
   "version": "1.7.4",
   "homepage": "http://dotdotdot.frebsite.nl/",
+  "repository": {
++    "type": "git",
++    "url": "https://github.com/BeSite/jQuery.dotdotdot.git"
++  },
   "author": "Fred Heusschen <info@frebsite.nl>",
   "description": "A jQuery plugin for advanced cross-browser ellipsis on multiple line content.",
   "keywords": [


### PR DESCRIPTION
This eliminates an NPM warning when installing the package.