### PR TITLE
Fix for #75. No need to detach the element and set the truncation to …

### DIFF
--- a/src/js/jquery.dotdotdot.js
+++ b/src/js/jquery.dotdotdot.js
@@ -396,12 +396,6 @@
 							{
 								isTruncated = ellipsis( $e, $d, $i, o, after );
 							}
-
-							if ( !isTruncated )
-							{
-								$e.detach();
-								isTruncated = true;
-							}
 						}
 
 						if ( !isTruncated )


### PR DESCRIPTION
…true. The truncation can be set to true in the next child iteration if applicable

```
In this particular example (http://codepen.io/anon/pen/doVdBo), it was trying to add 'after' after the first <p> which is exceeding the threshold, so it calls ellipsis on <p>.

In the ellipsis of <p>, it tries to add 'after' to the content (textnode), and the height doesn't exeed the threshold, so it returns isTruncated set to false and thus resulting in both removal of element as well as 'after'!

I personally feel this block of code is not required, as the 'isTruncated' (if applicable) will be set to true when we try to add next child anyways.

```