### PR TITLE
Make it useable for CJS and browersify

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,12 +1,12 @@
 {
   "name": "jQuery.dotdotdot",
   "main": "src/js/jquery.dotdotdot.js",
-  "version": "1.7.4",
+  "version": "1.7.5",
   "homepage": "http://dotdotdot.frebsite.nl/",
   "repository": {
-+    "type": "git",
-+    "url": "https://github.com/BeSite/jQuery.dotdotdot.git"
-+  },
+    "type": "git",
+    "url": "https://github.com/BeSite/jQuery.dotdotdot.git"
+  },
   "author": "Fred Heusschen <info@frebsite.nl>",
   "description": "A jQuery plugin for advanced cross-browser ellipsis on multiple line content.",
   "keywords": [

--- a/src/js/jquery.dotdotdot.js
+++ b/src/js/jquery.dotdotdot.js
@@ -10,6 +10,7 @@
  *	Licensed under the MIT license.
  *	http://en.wikipedia.org/wiki/MIT_License
  */
+var jQuery = require('jquery');
 
 (function( $, undef )
 {

--- a/src/js/jquery.dotdotdot.js
+++ b/src/js/jquery.dotdotdot.js
@@ -10,7 +10,7 @@
  *	Licensed under the MIT license.
  *	http://en.wikipedia.org/wiki/MIT_License
  */
-var jQuery = require('jquery');
+var jQuery = jQuery || require && require('jquery');
 
 (function( $, undef )
 {


### PR DESCRIPTION
Not sure if this is generic enough in order to be merged but with the fix we are able to use in CJS/browserify like this

// require jquery at some point
var jQuery = require('jquery')
// at some other point require jQuery.dotdotdot
require('jQuery.dotdotdot');