### PR TITLE
Remove is-truncated class when destroying instance

### DIFF
--- a/src/js/jquery.dotdotdot.js
+++ b/src/js/jquery.dotdotdot.js
@@ -181,6 +181,7 @@
 						.end()
 						.append( orgContent )
 						.attr( 'style', $dot.data( 'dotdotdot-style' ) || '' )
+						.removeClass('is-truncated')
 						.data( 'dotdotdot', false );
 				}
 			);


### PR DESCRIPTION
All related classes should be removed from elements when the instance is destroyed.